### PR TITLE
Convert env variables into hash to solve bug

### DIFF
--- a/lib/tfctl/executor.rb
+++ b/lib/tfctl/executor.rb
@@ -49,9 +49,7 @@ module Tfctl
                 'TF_IN_AUTOMATION'   => 'true',
             }
 
-            terraform_env = ENV.keep_if do |variable_name|
-                variable_name.start_with?('TF_')
-            end.merge(enforced_terraform_environment)
+            terraform_env = ENV.to_h.merge(enforced_terraform_environment)
 
             log.debug "#{account_name}: Executing: #{exec.shelljoin}"
 


### PR DESCRIPTION
This solve a bug that happens when trying to merge env variables into a hash. It generates the error below if this bugfix is not applied

```
tfctl-1.2.1/lib/tfctl/executor.rb:54:in `run': undefined method `merge' for {}:Object (NoMethodError)
```

It also solved bug #14 and #12 