### PR TITLE
Use new provider syntax

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_WITH: "developement"
+BUNDLE_BIN: "vendor/bin"

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 pkg/
 *.gem
 vendor/
-.bundle
 bin/bundle
 bin/htmldiff
 bin/ldiff

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,6 +1,13 @@
 = Changelog
 
-== Upcoming
+== 1.3
+
+ * feat: support new Terraform provider syntax
+
+BREAKING CHANGE: The minimum supported Terraform version has been bumped to
+0.12.29.  If you are running an older version of Terraform you will need to
+update to the latest Terraform in 0.12.x series before updating tfctl.  Once
+tfctl is updated you can upgrade Terraform to further versions.
 
 == 1.2.2
  * chore: reverted PR #11 - not necessary and introduced regression.  See PR #13 for details.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 
 vendor:
 	$(info => Installing Ruby dependencies)
-	@bundle install --path vendor --with developement --binstubs=vendor/bin
+	@bundle install
+	@bundle binstubs --all --path vendor/bin
 
 test: vendor rubocop spec
 

--- a/README.adoc
+++ b/README.adoc
@@ -31,23 +31,6 @@ toc::[]
 `tfctl` is a small Terraform wrapper for working with multi-account AWS
 infrastructures where new accounts may be created dynamically and on-demand.
 
-`tfctl` is an open source project published by The Scale Factory.
-
-We currently consider this project to be adopted.
-
-These are projects that we actively invest in because we or our customers find
-them useful on a day to day basis. We keep them security patched and ready for
-use in production environments.
-
-We’ll take a look at any issues or PRs you open and get back to you as soon as
-we can. We don’t offer any formal SLA, but we’ll be checking on this project
-periodically.
-
-If your issue is urgent, you can flag it as such, and we’ll attempt to triage
-appropriately, but we have paying customers who also have demands on our time.
-If your business depends on this project and you have an urgent problem, then
-you can talk to our sales team about paying us to support you.
-
 It discovers accounts by reading the AWS Organizations API, and can assign
 Terraform resources to multiple accounts based on the organization hierarchy.
 Resources can be assigned globally, based on organization unit or to individual
@@ -58,6 +41,23 @@ The Scale Factory originally created tfctl to integrate Terraform with
 https://aws.amazon.com/solutions/aws-landing-zone/[AWS Landing Zone] and
 https://aws.amazon.com/controltower/[Control Tower] but should work with most
 other ways of managing accounts in AWS Organizations.
+
+== Project status
+
+`tfctl` is an open source project published by The Scale Factory.
+
+We currently consider this project to be maintained but we don't actively
+develop new features.  We keep it security patched and ready for use in
+production environments.
+
+We’ll take a look at any issues or PRs you open and get back to you as soon as
+we can. We don’t offer any formal SLA, but we’ll be checking on this project
+periodically.
+
+If your issue is urgent, you can flag it as such, and we’ll attempt to triage
+appropriately, but we have paying customers who also have demands on our time.
+If your business depends on this project and you have an urgent problem, then
+you can talk to our sales team about paying us to support you.
 
 == Features
 
@@ -74,7 +74,7 @@ other ways of managing accounts in AWS Organizations.
 
 == Requirements
 
- * Terraform >= 0.12
+ * Terraform >= 0.12.29
  * Ruby >= 2.5
  * Accounts managed in AWS Organizations (by Landing Zone, Control Tower, some
    other means)

--- a/examples/control_tower/tfctl.yaml
+++ b/examples/control_tower/tfctl.yaml
@@ -17,7 +17,7 @@ tf_state_dynamodb_table: 'terraform-lock'
 tf_state_region: 'eu-west-1'
 # Role for accessing state resources
 tf_state_role_arn: 'arn:aws:iam::SHARED_SERVICES_ACCOUNT_ID:role/TerraformStateRole'
-tf_required_version: '>= 0.12.0'
+tf_required_version: '>= 0.12.29'
 aws_provider_version: '>= 2.14'
 # Role used by tfctl to retrieve data from AWS Organizations
 # Has to be set up in the primary org account

--- a/lib/tfctl/config.rb
+++ b/lib/tfctl/config.rb
@@ -121,7 +121,9 @@ module Tfctl
             return config unless config.key?(:exclude_accounts)
 
             config[:accounts].each_with_index do |account, idx|
+                # rubocop:disable Style/IfWithBooleanLiteralBranches
                 config[:accounts][idx][:excluded] = config[:exclude_accounts].include?(account[:name]) ? true : false
+                # rubocop:enable Style/IfWithBooleanLiteralBranches
             end
 
             config

--- a/lib/tfctl/version.rb
+++ b/lib/tfctl/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tfctl
-    VERSION = '1.2.2'
+    VERSION = '1.3.0'
 end

--- a/spec/data/config.yaml
+++ b/spec/data/config.yaml
@@ -6,7 +6,7 @@ tf_state_bucket: 'terraform-state'
 tf_state_role_arn: 'arn:aws:iam::012345678900:role/TerraformStateUser'
 tf_state_dynamodb_table: 'terraform-lock'
 tf_state_region: 'eu-west-1'
-tf_required_version: '>= 0.12.0'
+tf_required_version: '>= 0.12.29'
 aws_provider_version: '>= 2.14'
 tfctl_role_arn: 'arn:aws:iam::012345678900:role/TfCtlUser'
 

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe Tfctl::Generator do
         file = File.read("#{@generated_dir}/provider.tf.json")
         provider = JSON.parse(file)['provider']
 
-        expect(provider['aws']['version']).to eq(@config[:aws_provider_version])
         expect(provider['aws']['region']).to eq(@account[:region])
         expect(provider['aws']['assume_role']['role_arn']).to eq("arn:aws:iam::#{@account[:id]}:role/#{@account[:tf_execution_role]}")
     end
@@ -45,6 +44,8 @@ RSpec.describe Tfctl::Generator do
         terraform = JSON.parse(file)['terraform']
 
         expect(terraform['required_version']).to eq(@config[:tf_required_version])
+        expect(terraform['required_providers']['aws']['source']).to eq('hashicorp/aws')
+        expect(terraform['required_providers']['aws']['version']).to eq(@config[:aws_provider_version])
         expect(terraform['backend']['s3']['bucket']).to eq(@config[:tf_state_bucket])
         expect(terraform['backend']['s3']['key']).to eq("#{@account[:name]}/tfstate")
         expect(terraform['backend']['s3']['region']).to eq(@account[:region])
@@ -67,7 +68,6 @@ RSpec.describe Tfctl::Generator do
 
         expect(profile_module[profile_name]['source']).to eq("../../../profiles/#{profile_name}")
         expect(profile_module[profile_name]['config']).to eq('${var.config}')
-        expect(profile_module[profile_name]['providers']['aws']).to eq('aws')
     end
 
     it 'generates valid config auto tfvars' do

--- a/tfctl.gemspec
+++ b/tfctl.gemspec
@@ -32,7 +32,8 @@ Gem::Specification.new do |spec|
     spec.add_dependency 'parallel',              '~> 1.19'
     spec.add_dependency 'terminal-table',        '>= 1.8', '< 4.0'
 
-    spec.add_development_dependency 'guard-rspec', '~> 4.7'
-    spec.add_development_dependency 'rspec',       '~> 3.9'
-    spec.add_development_dependency 'rubocop',     '~> 1.3'
+    spec.add_development_dependency 'guard-rspec',   '~> 4.7'
+    spec.add_development_dependency 'rspec',         '~> 3.9'
+    spec.add_development_dependency 'rubocop',       '~> 1.3'
+    spec.add_development_dependency 'rubocop-rspec', '~> 2.2'
 end


### PR DESCRIPTION
Update generator to use the new provider syntax as introduced in Terraform 0.13:

https://www.terraform.io/upgrade-guides/0-13.html#explicit-provider-source-locations

This change also bumps the minimum supported Terraform version by tfctl to 0.12.29 which has partial support for the new syntax to make upgrades easier.

Issue reported in #28 