### PR TITLE
S3 state file key prefix

### DIFF
--- a/examples/control_tower/tfctl.yaml
+++ b/examples/control_tower/tfctl.yaml
@@ -13,6 +13,7 @@
 #
 
 tf_state_bucket: 'CHANGEME'
+# tf_state_prefix: ''
 tf_state_dynamodb_table: 'terraform-lock'
 tf_state_region: 'eu-west-1'
 # Role for accessing state resources

--- a/lib/tfctl/generator.rb
+++ b/lib/tfctl/generator.rb
@@ -16,6 +16,7 @@ module Tfctl
 
         def make(account:, config:)
             target_dir = "#{PROJECT_ROOT}/.tfctl/#{config[:config_name]}/#{account[:name]}"
+            tf_state_prefix = config.fetch(:tf_state_prefix, '').delete_suffix('/')
             tf_version = config.fetch(:tf_required_version, '>= 0.12.29')
             aws_provider_version = config.fetch(:aws_provider_version, '>= 2.14')
 
@@ -33,7 +34,7 @@ module Tfctl
                     'backend'            => {
                         's3' => {
                             'bucket'         => config[:tf_state_bucket],
-                            'key'            => "#{account[:name]}/tfstate",
+                            'key'            => [tf_state_prefix, account[:name], 'tfstate'].join('/').delete_prefix('/'),
                             'region'         => config[:tf_state_region],
                             'role_arn'       => config[:tf_state_role_arn],
                             'dynamodb_table' => config[:tf_state_dynamodb_table],

--- a/lib/tfctl/schema.rb
+++ b/lib/tfctl/schema.rb
@@ -34,6 +34,7 @@ module Tfctl
                     'type'       => 'object',
                     'properties' => {
                         'tf_state_bucket'         => { 'type' => 'string' },
+                        'tf_state_prefix'         => { 'type' => 'string' },
                         'tf_state_role_arn'       => {
                             'type'    => 'string',
                             'pattern' => iam_arn_pattern,

--- a/spec/data/config.yaml
+++ b/spec/data/config.yaml
@@ -3,6 +3,7 @@
 # Terraform settings
 
 tf_state_bucket: 'terraform-state'
+tf_state_prefix: 'prefix'
 tf_state_role_arn: 'arn:aws:iam::012345678900:role/TerraformStateUser'
 tf_state_dynamodb_table: 'terraform-lock'
 tf_state_region: 'eu-west-1'

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Tfctl::Generator do
         expect(terraform['required_providers']['aws']['source']).to eq('hashicorp/aws')
         expect(terraform['required_providers']['aws']['version']).to eq(@config[:aws_provider_version])
         expect(terraform['backend']['s3']['bucket']).to eq(@config[:tf_state_bucket])
-        expect(terraform['backend']['s3']['key']).to eq("#{@account[:name]}/tfstate")
+        expect(terraform['backend']['s3']['key']).to eq("#{@config[:tf_state_prefix]}/#{@account[:name]}/tfstate")
         expect(terraform['backend']['s3']['region']).to eq(@account[:region])
         expect(terraform['backend']['s3']['role_arn']).to eq(@config[:tf_state_role_arn])
         expect(terraform['backend']['s3']['dynamodb_table']).to eq(@config[:tf_state_dynamodb_table])


### PR DESCRIPTION
This adds an optional configuration that can add a prefix to the state file key name.

Useful when the state file bucket already contains other states and you want to keep things tidy.