### PR TITLE
Add version number in output log

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,3 +1,4 @@
 ---
 BUNDLE_PATH: "vendor/bundle"
 BUNDLE_BIN: "vendor/bin"
+BUNDLE_WITH: "developement"

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,6 +6,7 @@
    For details see: https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider
  * feat: new `tf_state_prefix` config parameter. (Thanks @patrickli)
    Allows setting an path prefix for state files stored in S3.
+ * feat: print version number in output log
 
 == 1.4.0
 

--- a/bin/tfctl
+++ b/bin/tfctl
@@ -138,7 +138,7 @@ begin
     log_level = options[:debug] ? Logger::DEBUG : Logger::INFO
     log = Tfctl::Logger.new(log_level)
 
-    log.info 'tfctl running'
+    log.info "tfctl #{Tfctl::VERSION} running"
 
     config_name = File.basename(options[:config_file]).chomp('.yaml')
     config_name = 'default' if config_name == 'tfctl'


### PR DESCRIPTION
Tiny change to add a version number to the output log to make it easier to see which version is being executed.  Handy when testing and debugging releases.