### PR TITLE
Pass default aws provider explicitly

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,23 @@
 = Changelog
 
+== 1.6.0
+
+ * fix: pass the default AWS provider explicitly from tfctl generated configuration.
+   This fixes provider inheritance issues when using multiple providers which
+   was introduced in 1.3.0.  You may need to add a terraform block with
+   `required_provides` to your profiles if you don't have it defined already.
+   Terraform will warn about this during `init`.  Here's an example block:
+
+----
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+----
+
 == 1.5.0
 
  * feat: support for setting default tags at AWS provider level.  (Thanks @patrickli)

--- a/examples/control_tower/modules/s3-bucket/main.tf
+++ b/examples/control_tower/modules/s3-bucket/main.tf
@@ -2,3 +2,7 @@ resource aws_s3_bucket bucket {
   bucket = var.name
   acl    = "private"
 }
+
+output "arn" {
+  value = aws_s3_bucket.bucket.arn
+}

--- a/examples/control_tower/profiles/example-profile/main.tf
+++ b/examples/control_tower/profiles/example-profile/main.tf
@@ -1,4 +1,11 @@
+resource "random_pet" "bucket_prefix" {
+}
+
 module "bucket" {
   source = "../../modules/s3-bucket"
-  name   = "${local.account_id}-${local.account["data"]["example_bucket_name"]}"
+  name   = "${random_pet.bucket_prefix.id}-${local.account["data"]["example_bucket_name"]}"
+}
+
+output "bucket_arn" {
+  value = module.bucket.arn
 }

--- a/examples/control_tower/profiles/example-profile/terraform.tf
+++ b/examples/control_tower/profiles/example-profile/terraform.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/examples/control_tower/profiles/example-profile/variables.tf
+++ b/examples/control_tower/profiles/example-profile/variables.tf
@@ -6,7 +6,7 @@ variable "config" {
 
 locals {
   config     = jsondecode(var.config)
-  account_id = "${data.aws_caller_identity.current.account_id}"
+  account_id = data.aws_caller_identity.current.account_id
   # get account configuration from tfctl config
-  account    = [ for account in local.config["accounts"]: account if account["id"] == local.account_id ][0]
+  account = [for account in local.config["accounts"] : account if account["id"] == local.account_id][0]
 }

--- a/lib/tfctl/generator.rb
+++ b/lib/tfctl/generator.rb
@@ -80,8 +80,11 @@ module Tfctl
                 profile_block = {
                     'module' => {
                         profile => {
-                            'source' => "../../../profiles/#{profile}",
-                            'config' => '${var.config}',
+                            'source'    => "../../../profiles/#{profile}",
+                            'config'    => '${var.config}',
+                            'providers' => {
+                                'aws' => 'aws',
+                            },
                         },
                     },
                 }

--- a/lib/tfctl/version.rb
+++ b/lib/tfctl/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tfctl
-    VERSION = '1.5.0'
+    VERSION = '1.6.0'
 end


### PR DESCRIPTION
In version 1.3.0 we moved to implicit provider passing from tfctl generated code to the profiles.  This caused issues for folks using multiple providers where the default provider must be passed explicitly.  This PR reverts the behaviour to explicit provider passing.