### PR TITLE
feat: basic support for running TF commands on Windows

### DIFF
--- a/lib/tfctl/executor.rb
+++ b/lib/tfctl/executor.rb
@@ -41,6 +41,12 @@ module Tfctl
             # Create the command
             exec = [cmd] + [subcmd] + args
 
+            runcmd = if Gem.win_platform?
+                         exec.join(' ')
+                     else
+                         exec.shelljoin
+                     end
+
             # Set environment variables for Terraform
             env = {
                 'TF_INPUT'           => '0',
@@ -49,10 +55,10 @@ module Tfctl
                 # 'TF_LOG'             => 'TRACE'
             }
 
-            log.debug "#{account_name}: Executing: #{exec.shelljoin}"
+            log.debug "#{account_name}: Executing: #{runcmd}"
 
             FileUtils.cd path
-            Open3.popen3(env, exec.shelljoin) do |stdin, stdout, stderr, wait_thr|
+            Open3.popen3(env, runcmd) do |stdin, stdout, stderr, wait_thr|
                 stdin.close_write
 
                 # capture stdout and stderr in separate threads to prevent deadlocks


### PR DESCRIPTION
I have a colleague who was trying to use `tfctl` from Windows 10 and ran into an issue when trying to run a `plan`:

```
PS C:\Users\User01\proj> tfctl -u -a my-account -- plan
info: tfctl 1.6.0 running
info: Using config: tfctl-niaid
info: Working out AWS account topology
info: Merging configuration
info: my-account: Generating Terraform run directory
info: my-account: Executing Terraform plan
error: my-account: ╷
error: my-account: │ Error: Failed to parse command-line flags
error: my-account: │
error: my-account: │ flag provided but not defined: -out\
```

As best as I can tell, `shellwords` does not support Windows-based shell quoting/arg manipulation and was mangling the arguments being passed in.  

The solution in this PR is likely missing support for all sorts of edge cases, but it seems to work fine with `plan` and `apply`, including extra arguments being passed in, though they need to be double-quoted, e.g.:

    tfctl -u -a my-account -- plan "-target=module.mymodule"

This could be missing other things too, since I seldom use Windows, but hopefully this can help others with at least basic support.