### PR TITLE
Account listing pagination fix

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,9 @@
 = Changelog
 
+== 1.6.1
+
+ * fix: pagination problem when listing accounts in an OU.
+
 == 1.6.0
 
  * fix: pass the default AWS provider explicitly from tfctl generated configuration.

--- a/lib/tfctl/aws_org.rb
+++ b/lib/tfctl/aws_org.rb
@@ -25,19 +25,22 @@ module Tfctl
 
                 parent_id = aws_ou_ids[ou_path]
 
-                @aws_org_client.list_accounts_for_parent(parent_id: parent_id).accounts.each do |account|
-                    next unless account.status == 'ACTIVE'
+                @aws_org_client.list_accounts_for_parent(parent_id: parent_id).each do |response|
+                    response.accounts.each do |account|
+                        next unless account.status == 'ACTIVE'
 
-                    output[:accounts] << {
-                        name:       account.name,
-                        id:         account.id,
-                        arn:        account.arn,
-                        email:      account.email,
-                        ou_path:    ou_path.to_s,
-                        ou_parents: ou_path.to_s.split('/'),
-                        profiles:   [],
-                    }
+                        output[:accounts] << {
+                            name:       account.name,
+                            id:         account.id,
+                            arn:        account.arn,
+                            email:      account.email,
+                            ou_path:    ou_path.to_s,
+                            ou_parents: ou_path.to_s.split('/'),
+                            profiles:   [],
+                        }
+                    end
                 end
+
             end
             output
         end
@@ -71,8 +74,8 @@ module Tfctl
             @aws_org_client.list_children(
                 child_type: 'ORGANIZATIONAL_UNIT',
                 parent_id:  parent_id,
-            ).each do |resp|
-                resp.children.each do |child|
+            ).each do |response|
+                response.children.each do |child|
 
                     begin
                         ou = @aws_org_client.describe_organizational_unit(

--- a/lib/tfctl/version.rb
+++ b/lib/tfctl/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tfctl
-    VERSION = '1.6.0'
+    VERSION = '1.6.1'
 end

--- a/tfctl.gemspec
+++ b/tfctl.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
     end
     spec.bindir        = 'bin'
     spec.executables   = spec.files.grep(%r{^bin/tfctl}) { |f| File.basename(f) }
-    spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
     spec.require_paths = ['lib']
 
     spec.required_ruby_version = '>= 2.5.0'


### PR DESCRIPTION
Fixes a pagination problem when listing AWS accounts in an OU containing more than 20 accounts.