### PR TITLE
Parallelism flag and enhanced executor error output

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -3,6 +3,9 @@
 == 1.7.0
 
  * feat: added a `-p` flag to configure parallelism
+ * feat: enhanced the executor output when raising `Tfctl::Error`, it will now
+   report the `account_name` that raised the error along with the full command
+   that was being run
 
 == 1.6.1
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,9 @@
 = Changelog
 
+== 1.7.0
+
+ * feat: added a `-p` flag to configure parallelism
+
 == 1.6.1
 
  * fix: pagination problem when listing accounts in an OU.

--- a/bin/tfctl
+++ b/bin/tfctl
@@ -57,8 +57,8 @@ optparse = OptionParser.new do |opts|
     opts.on('-d', '--debug', 'Turn on debug messages') do
         options[:debug] = true
     end
-    opts.on('-p', '--parallelism', 'How many terraform processes to execute in parallel') do
-        options[:debug] = true
+    opts.on('-p', '--parallelism=num', 'How many terraform processes to execute in parallel') do |o|
+        options[:parallelism] = o.to_i
     end
     opts.on('-v', '--version', 'Show version') do
         puts Tfctl::VERSION

--- a/bin/tfctl
+++ b/bin/tfctl
@@ -26,6 +26,7 @@ options = {
     unbuffered:  false,
     debug:       false,
     use_cache:   false,
+    parallelism: 8,
 }
 
 optparse = OptionParser.new do |opts|
@@ -54,6 +55,9 @@ optparse = OptionParser.new do |opts|
         options[:unbuffered] = true
     end
     opts.on('-d', '--debug', 'Turn on debug messages') do
+        options[:debug] = true
+    end
+    opts.on('-p', '--parallelism', 'How many terraform processes to execute in parallel') do
         options[:debug] = true
     end
     opts.on('-v', '--version', 'Show version') do
@@ -93,7 +97,7 @@ begin
         raise OptionParser::InvalidOption, 'Please specify target'
     end
 rescue OptionParser::InvalidOption, OptionParser::MissingArgument
-    warn $ERROR_INFO.to_s
+    warn $ERROR_INFO
     warn optparse
     exit 2
 end
@@ -202,7 +206,7 @@ begin
 
     # Execute Terraform in target accounts
 
-    Parallel.each(accounts, in_processes: 8) do |ac|
+    Parallel.each(accounts, in_processes: options[:parallelism]) do |ac|
         run_account(config, ac, options, ARGV, log)
     end
 

--- a/lib/tfctl/executor.rb
+++ b/lib/tfctl/executor.rb
@@ -88,7 +88,7 @@ module Tfctl
                 FileUtils.rm_f plan_file if args[0] == 'apply' # tidy up the plan file
 
                 unless status.exitstatus.zero?
-                    raise Tfctl::Error, "#{cmd} failed with exit code: #{status.exitstatus}"
+                    raise Tfctl::Error, "#{account_name}: #{runcmd} failed with exit code: #{status.exitstatus}"
                 end
             end
         end

--- a/lib/tfctl/version.rb
+++ b/lib/tfctl/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tfctl
-    VERSION = '1.6.1'
+    VERSION = '1.7.0'
 end


### PR DESCRIPTION
This PR takes @word's existing branch and makes the following changes:

   - Finishes implementing the `--parallelism` flag
   - Enhances the `executor` `Tfctl::Error` output by including the `account_name` and `runcmd` in the raised error message

The enhanced `executor` error message should make it much easier to locate errors that caused a run to fail.